### PR TITLE
PR: make print() and __repr__() return the same string for Graph objects

### DIFF
--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import functools
+
 from typing import List
 from yaml import dump, load
 
@@ -49,14 +51,24 @@ class Node(object):
         return self._threads[key]
 
     def __repr__(self) -> str:
-        if len(self.threads) > 0:
-            # print('not self')
-            return "".join(["{",
-                            "{}:{}".format(self.name,
-                                           self.threads),
-                            "}"])
-        # print('self')
-        return "{}".format(self.name)
+        return self.custom_repr(self, 0)
+
+    @staticmethod
+    def custom_repr(node: "Node", depth: int =0) -> str:
+
+        if len(node.threads) > 0:
+
+            if depth == 0:
+                return node.name + ":\n" + '\n'.join(
+                    map(functools.partial(node.custom_repr, depth=depth+1), node.threads))
+            elif depth == 1:
+                return '- ' + node.name + ":\n" + '\n'.join(
+                    map(functools.partial(node.custom_repr, depth=depth + 1), node.threads))
+            else:
+                return "    "*(depth-1) + "- {}".format(node.name) + ":\n" + '\n'.join(
+                    map(functools.partial(node.custom_repr, depth=depth + 1), node.threads))
+
+        return "    "*(depth-1) + "- {}".format(node.name)
 
     def __str__(self) -> str:
         return dump(load(str(self.__repr__())), default_flow_style=False)

--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import functools
+
 from typing import List
 from yaml import dump, load
 
@@ -49,14 +51,24 @@ class Node(object):
         return self._threads[key]
 
     def __repr__(self) -> str:
-        if len(self.threads) > 0:
-            # print('not self')
-            return "".join(["{",
-                            "{}:{}".format(self.name,
-                                           self.threads),
-                            "}"])
-        # print('self')
-        return "{}".format(self.name)
+        return self.custom_repr(self, 0)
+
+    @staticmethod
+    def custom_repr(node: "Node", deep: int =0) -> str:
+
+        if len(node.threads) > 0:
+
+            if deep == 0:
+                return node.name + ":\n" + '\n'.join(
+                    map(functools.partial(node.custom_repr, deep=deep+1), node.threads))
+            elif deep == 1:
+                return '- ' + node.name + ":\n" + '\n'.join(
+                    map(functools.partial(node.custom_repr, deep=deep + 1), node.threads))
+            else:
+                return "    "*(deep-1) + "- {}".format(node.name) + ":\n" + '\n'.join(
+                    map(functools.partial(node.custom_repr, deep=deep + 1), node.threads))
+
+        return "    "*(deep-1) + "- {}".format(node.name)
 
     def __str__(self) -> str:
         return dump(load(str(self.__repr__())), default_flow_style=False)

--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -54,21 +54,26 @@ class Node(object):
         return self.custom_repr(self, 0)
 
     @staticmethod
-    def custom_repr(node: "Node", depth: int =0) -> str:
+    def custom_repr(node: "Node", depth: int = 0) -> str:
 
         if len(node.threads) > 0:
 
             if depth == 0:
                 return node.name + ":\n" + '\n'.join(
-                    map(functools.partial(node.custom_repr, depth=depth+1), node.threads))
+                    map(functools.partial(node.custom_repr, depth=depth + 1),
+                        node.threads))
             elif depth == 1:
                 return '- ' + node.name + ":\n" + '\n'.join(
-                    map(functools.partial(node.custom_repr, depth=depth + 1), node.threads))
+                    map(functools.partial(node.custom_repr, depth=depth + 1),
+                        node.threads))
             else:
-                return "    "*(depth-1) + "- {}".format(node.name) + ":\n" + '\n'.join(
-                    map(functools.partial(node.custom_repr, depth=depth + 1), node.threads))
+                return "    " * (depth - 1) + "- {}".format(node.name) + \
+                       ":\n" + '\n'.join(map(
+                                         functools.partial(node.custom_repr,
+                                                           depth=depth + 1),
+                                         node.threads))
 
-        return "    "*(depth-1) + "- {}".format(node.name)
+        return "    " * (depth - 1) + "- {}".format(node.name)
 
     def __str__(self) -> str:
         return dump(load(str(self.__repr__())), default_flow_style=False)

--- a/test/test_mindgraph.py
+++ b/test/test_mindgraph.py
@@ -98,6 +98,25 @@ def test_repr(graph):
     ])
 
 
+def test_deep_repr(graph):
+
+    thing2_1 = graph[1][0]
+    assert thing2_1.name == 'another thing within a thing'
+
+    thing2_1.append('super deep thing')
+
+    assert str(graph) == "".join([
+        "learn all the things:\n",
+        "- 1st thing:\n",
+        "  - thing within a thing\n",
+        "  - thing blocking a thing\n",
+        "- 2nd thing:\n"
+        "  - another thing within a thing:\n",
+        "    - super deep thing\n"
+        "  - another thing blocking a thing\n",
+    ])
+
+    thing2_1.pop(0)
 def test_weight_getter_setter():
     node = Node('myNode')
     default_weight = node.weight

--- a/test/test_mindgraph.py
+++ b/test/test_mindgraph.py
@@ -117,6 +117,8 @@ def test_deep_repr(graph):
     ])
 
     thing2_1.pop(0)
+
+
 def test_weight_getter_setter():
     node = Node('myNode')
     default_weight = node.weight


### PR DESCRIPTION
Issue: #4 

I wrote a custom_repr function that takes as input the node and an int that represent the depth of that node for printing with the right indentation.

the __repr__ function calls this custom function passing 0 as depth

I know you posted that link, but with repr you can't have parameters instead i needed one