### PR TITLE
resolve #14: add sorted todo list based on task precedence

### DIFF
--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -6,10 +6,6 @@ from typing import (Any, Callable, Generator, Iterator, List, Optional, Set,
 from yaml import dump, load
 
 
-def identity(x):
-    return x
-
-
 class Node(object):
     """node class"""
 
@@ -82,13 +78,17 @@ class Node(object):
     def _postorder(self,
                    depth: int = 0,
                    visited: Set["Node"] = None,
-                   node_key: Callable[["Node"], Any]=identity,
+                   node_key: Callable[["Node"], Any]=None,
                    ) -> Generator[Tuple[int, "Node"], None, Set["Node"]]:
         """Post-order traversal of graph rooted at node"""
         if visited is None:
             visited = set()
 
-        for child in sorted(self._threads, key=node_key):
+        children = self._threads
+        if node_key is not None:
+            children = sorted(self._threads, key=node_key)
+
+        for child in children:
             if child not in visited:
                 visited = yield from child._postorder(depth+1,
                                                       visited,

--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -6,6 +6,10 @@ from typing import (Any, Callable, Generator, Iterator, List, Optional, Set,
 from yaml import dump, load
 
 
+def identity(x):
+    return x
+
+
 class Node(object):
     """node class"""
 
@@ -73,27 +77,27 @@ class Node(object):
                                          functools.partial(node.custom_repr,
                                                            depth=depth + 1),
                                          node.threads))
+        return "    " * (depth - 1) + "- {}".format(node.name)
 
     def _postorder(self,
                    depth: int = 0,
                    visited: Set["Node"] = None,
-                   node_key: Callable[["Node"], Any] = lambda x: x,
+                   node_key: Callable[["Node"], Any]=identity,
                    ) -> Generator[Tuple[int, "Node"], None, Set["Node"]]:
         """Post-order traversal of graph rooted at node"""
-        from operator import attrgetter
-
         if visited is None:
             visited = set()
 
         for child in sorted(self._threads, key=node_key):
             if child not in visited:
-                visited = yield from child._postorder(depth+1, visited, node_key)
+                visited = yield from child._postorder(depth+1,
+                                                      visited,
+                                                      node_key)
 
         yield (depth, self)
         visited.add(self)
 
         return visited
-
 
     def todo(self) -> Iterator["Node"]:
         """Generate nodes in todo order
@@ -101,12 +105,9 @@ class Node(object):
         Nodes are scheduled by weight and to resolve blocking tasks
         """
         # sorts by weight (2 before 1), then alphabetical
-        node_key = lambda x: (-x.weight, x.name)
+        def node_key(node):
+            return (-node.weight, node.name)
         return (x[1] for x in self._postorder(node_key=node_key))
-
-
-
-        return "    " * (depth - 1) + "- {}".format(node.name)
 
     def __str__(self) -> str:
         return dump(load(str(self.__repr__())), default_flow_style=False)

--- a/test/test_mindgraph.py
+++ b/test/test_mindgraph.py
@@ -1,7 +1,9 @@
-from mindgraph import *
+import os
+
 import pytest
 import yaml
-import os
+
+from mindgraph import *
 
 
 @pytest.fixture(scope="module")
@@ -52,6 +54,12 @@ def test_todo_blocking_tasks_win(task_graph):
     assert todo.index('task 2.2') < todo.index('task 3.2')
     assert todo.index('task 2.2') < todo.index('task 1.2')
     assert todo.index('task 1.1') < todo.index('task 1.2')
+
+
+def test_postorder_default_weights_ignored(task_graph):
+    """Post-order traversal ignores node weights by default"""
+    po = [n.name for _, n in task_graph._postorder()]
+    assert po.index('task 1.1') < po.index('task 1.3')
 
 
 def test_node_init_typeerror():


### PR DESCRIPTION
This adds the desired todo listing specified in issue #14. `Node.todo()` returns a generator that emits nodes in topological order based on node weighting and the dependencies between nodes.

The implementation is based on a post-order graph traversal, which performs a depth-first search that processes all child nodes before the parent node.