### PR TITLE
resolve #21: Name changes for Graph, Node, and Node attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ $ pip install git+https://github.com/capsulecorplab/mindgraph.git
 ```
 >>> import mindgraph as mg
 
->>> graph = mg.Graph('learn all the things')
->>> thing1 = graph.append('1st thing')
->>> thing2 = graph.append('2nd thing')
->>> thing3 = graph.append('3rd thing')
+>>> project = mg.Project('learn all the things')
+>>> thing1 = project.append('1st thing')
+>>> thing2 = project.append('2nd thing')
+>>> thing3 = project.append('3rd thing')
 
->>> graph.remove(2)
+>>> project.remove(2)
 
->>> thing1 = graph[0]
+>>> thing1 = project[0]
 >>> thing1_1 = thing1.append('thing within a thing')
 >>> thing1_2 = thing1.append('thing blocking a thing')
 >>> thing1_1.blockedby(thing1_2)
@@ -36,7 +36,7 @@ $ pip install git+https://github.com/capsulecorplab/mindgraph.git
 >>> thing2_2 = thing2.append('another thing blocking a thing')
 >>> thing2_2.blocking(thing2_1)
 
->>> print(graph)
+>>> print(project)
 learn all the things:
 - 1st thing:
   - thing within a thing
@@ -46,11 +46,11 @@ learn all the things:
   - another thing blocking a thing
 ```
 
-`Graph` objects can be exported to, and imported from, a yaml file for storage:
+Projects can be exported to, or imported from, a yaml file for external storage:
 
 ```
->>> graph.to_yaml('mygraph.yaml')
->>> graph2 = mg.read_yaml('mygraph.yaml')
+>>> project.to_yaml('myproject.yaml')
+>>> revivedproject = mg.read_yaml('myproject.yaml')
 ```
 
 ## Contribute

--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -139,9 +139,10 @@ class Task(object):
             f.write(dump(self))
 
 
-def project(name: str=None) -> Task:
+class Project(object):
     """Returns a task representing the root of your project"""
-    return Task(name)
+    def __new__(cls, name: str=None) -> Task:
+        return Task(name)
 
 
 def read_yaml(filename: str = "") -> Task:

--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -139,18 +139,16 @@ class Task(object):
             f.write(dump(self))
 
 
-class Project(Task):
+def project(name: str=None) -> Task:
     """Returns a task representing the root of your project"""
-
-    def __init__(self, name=None) -> None:
-        Task.__init__(self, name)
+    return Task(name)
 
 
-def read_yaml(filename: str = "") -> Project:
-    """ Load a Project from a yaml file """
+def read_yaml(filename: str = "") -> Task:
+    """ Load a project from a yaml file """
     with open(filename, 'r') as f:
         rv = load(f.read())
-        if type(rv) is Project:
+        if type(rv) is Task:
             return rv
         else:
             raise TypeError(type(rv))

--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -69,21 +69,21 @@ class Task(object):
     def _postorder(self,
                    depth: int = 0,
                    visited: Set["Task"] = None,
-                   Task_key: Callable[["Task"], Any]=None,
+                   taskkey: Callable[["Task"], Any]=None,
                    ) -> Generator[Tuple[int, "Task"], None, Set["Task"]]:
         """Post-order traversal of Project rooted at Task"""
         if visited is None:
             visited = set()
 
         children = self._subtasks
-        if Task_key is not None:
-            children = sorted(self._subtasks, key=Task_key)
+        if taskkey is not None:
+            children = sorted(self._subtasks, key=taskkey)
 
         for child in children:
             if child not in visited:
                 visited = yield from child._postorder(depth+1,
                                                       visited,
-                                                      Task_key)
+                                                      taskkey)
 
         yield (depth, self)
         visited.add(self)
@@ -96,9 +96,9 @@ class Task(object):
         Tasks are scheduled by priority and to resolve blocking tasks
         """
         # sorts by priority (2 before 1), then alphabetical
-        def Task_key(Task):
+        def taskkey(Task):
             return (-Task.priority, Task.name)
-        return (x[1] for x in self._postorder(Task_key=Task_key))
+        return (x[1] for x in self._postorder(taskkey=taskkey))
 
     def __str__(self) -> str:
         return dump(load(str(self.__repr__())), default_flow_style=False)

--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -4,109 +4,109 @@ from typing import (Any, Callable, Generator, Iterator, List, Optional, Set,
 from yaml import dump, load
 
 
-class Node(object):
-    """node class"""
+class Task(object):
+    """Task class"""
 
-    def __init__(self, name: str = '', weight: int = 1) -> None:
-        self._dependencies = list()  # type: List[Node]
-        self._threads = list()  # type: List[Node]
+    def __init__(self, name: str = '', priority: int = 1) -> None:
+        self._blockers = list()  # type: List[Task]
+        self._subtasks = list()  # type: List[Task]
         self._name = ''  # type: str
-        self._weight = weight  # type: int
+        self._priority = priority  # type: int
         if type(name) is str:
             self._name = name
         else:
             raise TypeError
 
-    def append(self, newnode) -> "Node":
-        """ Creates a new Node and appends it to threads """
-        if type(newnode) is str:
-            newnode = Node(newnode)
-        elif type(newnode) is not Node:
+    def append(self, newTask) -> "Task":
+        """ Creates a new Task and appends it to subtasks """
+        if type(newTask) is str:
+            newTask = Task(newTask)
+        elif type(newTask) is not Task:
             raise TypeError
-        self._threads.append(newnode)
-        return newnode
+        self._subtasks.append(newTask)
+        return newTask
 
-    def pop(self, index: int) -> "Node":
-        """ Pops the Node from threads[index] """
-        return self._threads.pop(index)
+    def pop(self, index: int) -> "Task":
+        """ Pops the Task from subtasks[index] """
+        return self._subtasks.pop(index)
 
-    def blockedby(self, node: "Node") -> None:
-        """ Adds a Node to the dependenceis list """
-        if type(node) is Node:
-            self._dependencies.append(node)
+    def blockedby(self, task: "Task") -> None:
+        """ Adds a task to the subtasks list """
+        if type(task) is Task:
+            self._blockers.append(task)
             return None
         else:
             raise TypeError
 
-    def blocking(self, node: "Node") -> None:
-        """ Adds this Node to another node's dependencies list """
-        if type(node) is Node:
-            node._dependencies.append(self)
+    def blocking(self, task: "Task") -> None:
+        """ Adds this task to another task's blockers list """
+        if type(task) is Task:
+            task._blockers.append(self)
             return None
         else:
             raise TypeError
 
-    def __getitem__(self, key: int) -> "Node":
-        return self._threads[key]
+    def __getitem__(self, key: int) -> "Task":
+        return self._subtasks[key]
 
     def __repr__(self) -> str:
         return '\n'.join(self.format_tree())
 
-    def format_tree(self: "Node", depth: int = 0) -> Iterator[str]:
-        """Format node and dependents in tree format, emitting lines
+    def format_tree(self: "Task", depth: int = 0) -> Iterator[str]:
+        """Format Task and dependents in tree format, emitting lines
 
-        Assumes no cycles in graph
+        Assumes no cycles in Project
         """
         indent = '    ' * depth
         bullet = '- ' if depth != 0 else ''
-        suffix = ':' if self.threads else ''
+        suffix = ':' if self.subtasks else ''
         line = '{indent}{bullet}{self.name}{suffix}'.format(**locals())
 
         yield line
-        for n in self.threads:
+        for n in self.subtasks:
             yield from n.format_tree(depth+1)
 
     def _postorder(self,
                    depth: int = 0,
-                   visited: Set["Node"] = None,
-                   node_key: Callable[["Node"], Any]=None,
-                   ) -> Generator[Tuple[int, "Node"], None, Set["Node"]]:
-        """Post-order traversal of graph rooted at node"""
+                   visited: Set["Task"] = None,
+                   Task_key: Callable[["Task"], Any]=None,
+                   ) -> Generator[Tuple[int, "Task"], None, Set["Task"]]:
+        """Post-order traversal of Project rooted at Task"""
         if visited is None:
             visited = set()
 
-        children = self._threads
-        if node_key is not None:
-            children = sorted(self._threads, key=node_key)
+        children = self._subtasks
+        if Task_key is not None:
+            children = sorted(self._subtasks, key=Task_key)
 
         for child in children:
             if child not in visited:
                 visited = yield from child._postorder(depth+1,
                                                       visited,
-                                                      node_key)
+                                                      Task_key)
 
         yield (depth, self)
         visited.add(self)
 
         return visited
 
-    def todo(self) -> Iterator["Node"]:
-        """Generate nodes in todo order
+    def todo(self) -> Iterator["Task"]:
+        """Generate Tasks in todo order
 
-        Nodes are scheduled by weight and to resolve blocking tasks
+        Tasks are scheduled by priority and to resolve blocking tasks
         """
-        # sorts by weight (2 before 1), then alphabetical
-        def node_key(node):
-            return (-node.weight, node.name)
-        return (x[1] for x in self._postorder(node_key=node_key))
+        # sorts by priority (2 before 1), then alphabetical
+        def Task_key(Task):
+            return (-Task.priority, Task.name)
+        return (x[1] for x in self._postorder(Task_key=Task_key))
 
     def __str__(self) -> str:
         return dump(load(str(self.__repr__())), default_flow_style=False)
 
     @property
-    def dependencies(self) -> List["Node"]:
-        """ dependencies getter """
-        return self._dependencies
+    def blockers(self) -> List["Task"]:
+        """ blockers getter """
+        return self._blockers
 
     @property
     def name(self) -> str:
@@ -119,38 +119,38 @@ class Node(object):
         self._name = name
 
     @property
-    def threads(self) -> List["Node"]:
-        """ threads getter """
-        return self._threads
+    def subtasks(self) -> List["Task"]:
+        """ subtasks getter """
+        return self._subtasks
 
     @property
-    def weight(self) -> int:
-        """ weight getter """
-        return self._weight
+    def priority(self) -> int:
+        """ priority getter """
+        return self._priority
 
-    @weight.setter
-    def weight(self, value: int) -> None:
-        """ weight setter """
-        self._weight = value
-
-
-class Graph(Node):
-    """A Graph model of the mind"""
-
-    def __init__(self, name=None) -> None:
-        Node.__init__(self, name)
+    @priority.setter
+    def priority(self, value: int) -> None:
+        """ priority setter """
+        self._priority = value
 
     def to_yaml(self, filename=None) -> None:
-        """ Write this Graph to a yaml file """
+        """ Write this Project to a yaml file """
         with open(filename, 'w') as f:
             f.write(dump(self))
 
 
-def read_yaml(filename: str = "") -> Graph:
-    """ Load a Graph from a yaml file """
+class Project(Task):
+    """Returns a task representing the root of your project"""
+
+    def __init__(self, name=None) -> None:
+        Task.__init__(self, name)
+
+
+def read_yaml(filename: str = "") -> Project:
+    """ Load a Project from a yaml file """
     with open(filename, 'r') as f:
         rv = load(f.read())
-        if type(rv) is Graph:
+        if type(rv) is Project:
             return rv
         else:
             raise TypeError(type(rv))

--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -50,13 +50,10 @@ class Task(object):
         return self._subtasks[key]
 
     def __repr__(self) -> str:
-        return '\n'.join(self.format_tree())
+        return '\n'.join(self._format_tree())
 
-    def format_tree(self: "Task", depth: int = 0) -> Iterator[str]:
-        """Format Task and dependents in tree format, emitting lines
-
-        Assumes no cycles in Project
-        """
+    def _format_tree(self: "Task", depth: int = 0) -> Iterator[str]:
+        """Generates task and subtasks into a string formatted tree"""
         indent = '    ' * depth
         bullet = '- ' if depth != 0 else ''
         suffix = ':' if self.subtasks else ''
@@ -64,7 +61,7 @@ class Task(object):
 
         yield line
         for n in self.subtasks:
-            yield from n.format_tree(depth+1)
+            yield from n._format_tree(depth+1)
 
     def _postorder(self,
                    depth: int = 0,

--- a/mindgraph/graph.py
+++ b/mindgraph/graph.py
@@ -17,14 +17,14 @@ class Task(object):
         else:
             raise TypeError
 
-    def append(self, newTask) -> "Task":
+    def append(self, newtask) -> "Task":
         """ Creates a new Task and appends it to subtasks """
-        if type(newTask) is str:
-            newTask = Task(newTask)
-        elif type(newTask) is not Task:
+        if type(newtask) is str:
+            newtask = Task(newtask)
+        elif type(newtask) is not Task:
             raise TypeError
-        self._subtasks.append(newTask)
-        return newTask
+        self._subtasks.append(newtask)
+        return newtask
 
     def pop(self, index: int) -> "Task":
         """ Pops the Task from subtasks[index] """

--- a/test/test_mindgraph.py
+++ b/test/test_mindgraph.py
@@ -12,14 +12,14 @@ from mindgraph import *
 
 @pytest.fixture(scope="module")
 def graph():
-    graph = Project('learn all the things')
+    graph = project('learn all the things')
     return graph
 
 
 @pytest.fixture
 def task_graph():
     # setup example graph from issue #14
-    g = Project('build a thing')
+    g = project('build a thing')
 
     t1 = g.append('task 1')
     t1.priority = 3

--- a/test/test_mindgraph.py
+++ b/test/test_mindgraph.py
@@ -44,8 +44,8 @@ def task_project():
     return g
 
 
-def test_todo_high_prioritys_win(task_project):
-    """High prioritys are scheduled before low prioritys"""
+def test_todo_high_priorities_win(task_project):
+    """High priorities are scheduled before low priorities"""
     todo = [n.name for n in task_project.todo()]
     assert todo.index('task 1') < todo.index('task 2')
     assert todo.index('task 1') < todo.index('task 3')
@@ -60,8 +60,8 @@ def test_todo_blocking_tasks_win(task_project):
     assert todo.index('task 1.1') < todo.index('task 1.2')
 
 
-def test_postorder_default_prioritys_ignored(task_project):
-    """Post-order traversal ignores task prioritys by default"""
+def test_postorder_default_priorities_ignored(task_project):
+    """Post-order traversal ignores task priorities by default"""
     po = [n.name for _, n in task_project._postorder()]
     assert po.index('task 1.1') < po.index('task 1.3')
 

--- a/test/test_mindgraph.py
+++ b/test/test_mindgraph.py
@@ -12,24 +12,24 @@ from mindgraph import *
 
 @pytest.fixture(scope="module")
 def graph():
-    graph = Graph('learn all the things')
+    graph = Project('learn all the things')
     return graph
 
 
 @pytest.fixture
 def task_graph():
     # setup example graph from issue #14
-    g = Graph('build a thing')
+    g = Project('build a thing')
 
     t1 = g.append('task 1')
-    t1.weight = 3
+    t1.priority = 3
     t11 = t1.append('task 1.1')
     t12 = t1.append('task 1.2')
     t13 = t1.append('task 1.3')
-    t13.weight = 3
+    t13.priority = 3
 
     t2 = g.append('task 2')
-    t2.weight = 2
+    t2.priority = 2
     t21 = t2.append('task 2.1')
     t22 = t2.append('task 2.2')
     t221 = t22.append('task 2.2.1')
@@ -39,13 +39,13 @@ def task_graph():
     t31 = t3.append('task 3.1')
     t32 = t3.append('task 3.2')
 
-    t32.threads.append(t22)
-    t12.threads.append(t22)
+    t32.subtasks.append(t22)
+    t12.subtasks.append(t22)
     return g
 
 
-def test_todo_high_weights_win(task_graph):
-    """High weights are scheduled before low weights"""
+def test_todo_high_prioritys_win(task_graph):
+    """High prioritys are scheduled before low prioritys"""
     todo = [n.name for n in task_graph.todo()]
     assert todo.index('task 1') < todo.index('task 2')
     assert todo.index('task 1') < todo.index('task 3')
@@ -60,24 +60,24 @@ def test_todo_blocking_tasks_win(task_graph):
     assert todo.index('task 1.1') < todo.index('task 1.2')
 
 
-def test_postorder_default_weights_ignored(task_graph):
-    """Post-order traversal ignores node weights by default"""
+def test_postorder_default_prioritys_ignored(task_graph):
+    """Post-order traversal ignores node prioritys by default"""
     po = [n.name for _, n in task_graph._postorder()]
     assert po.index('task 1.1') < po.index('task 1.3')
 
 
 def test_node_init_typeerror():
     with pytest.raises(TypeError) as info:
-        node = Node(47)
+        node = Task(47)
         assert "" in str(info.value)
 
 
 def test_node_append_node():
-    rootNode = Node('root node')
-    subNode1 = rootNode.append(Node('sub node'))
-    subNode2 = rootNode.append(Node('sub node 2'))
-    assert rootNode[0] is subNode1
-    assert rootNode[1] is subNode2
+    rootTask = Task('root node')
+    subTask1 = rootTask.append(Task('sub node'))
+    subTask2 = rootTask.append(Task('sub node 2'))
+    assert rootTask[0] is subTask1
+    assert rootTask[1] is subTask2
 
 
 def test_node_append(graph):
@@ -109,7 +109,7 @@ def test_node_pop_fail1(graph):
 
 def test_node_append_TypeError():
     with pytest.raises(TypeError) as info:
-        node = Node('mynode')
+        node = Task('mynode')
         node.append(47)
         assert "" in str(info.value)
 
@@ -119,7 +119,7 @@ def test_blockedby(graph):
     thing1_1 = thing1.append('thing within a thing')
     thing1_2 = thing1.append('thing blocking a thing')
     thing1_1.blockedby(thing1_2)
-    assert thing1_1.dependencies[0].name == 'thing blocking a thing'
+    assert thing1_1.blockers[0].name == 'thing blocking a thing'
 
 
 def test_blocking(graph):
@@ -127,7 +127,7 @@ def test_blocking(graph):
     thing2_1 = thing2.append('another thing within a thing')
     thing2_2 = thing2.append('another thing blocking a thing')
     thing2_2.blocking(thing2_1)
-    assert thing2_1.dependencies[0].name == 'another thing blocking a thing'
+    assert thing2_1.blockers[0].name == 'another thing blocking a thing'
 
 
 def test_repr(graph):
@@ -175,17 +175,17 @@ def test_deep_repr(graph):
     thing2_1.pop(0)
 
 
-def test_weight_getter_setter():
-    node = Node('myNode')
-    default_weight = node.weight
-    node.weight = 5
+def test_priority_getter_setter():
+    node = Task('myTask')
+    default_priority = node.priority
+    node.priority = 5
 
-    assert default_weight == 1
-    assert node.weight == 5
+    assert default_priority == 1
+    assert node.priority == 5
 
 
 def test_name_getter_setter():
-    node = Node()
+    node = Task()
     default_name = node.name
     node.name = 'a new name'
 

--- a/test/test_mindgraph.py
+++ b/test/test_mindgraph.py
@@ -11,14 +11,14 @@ from mindgraph import *
 
 
 @pytest.fixture(scope="module")
-def graph():
-    graph = Project('learn all the things')
-    return graph
+def project():
+    project = Project('learn all the things')
+    return project
 
 
 @pytest.fixture
-def task_graph():
-    # setup example graph from issue #14
+def task_project():
+    # setup example project from issue #14
     g = Project('build a thing')
 
     t1 = g.append('task 1')
@@ -44,25 +44,25 @@ def task_graph():
     return g
 
 
-def test_todo_high_prioritys_win(task_graph):
+def test_todo_high_prioritys_win(task_project):
     """High prioritys are scheduled before low prioritys"""
-    todo = [n.name for n in task_graph.todo()]
+    todo = [n.name for n in task_project.todo()]
     assert todo.index('task 1') < todo.index('task 2')
     assert todo.index('task 1') < todo.index('task 3')
     assert todo.index('task 1.3') < todo.index('task 1.1')
 
 
-def test_todo_blocking_tasks_win(task_graph):
+def test_todo_blocking_tasks_win(task_project):
     """Blocking tasks are scheduled before blocked tasks"""
-    todo = [n.name for n in task_graph.todo()]
+    todo = [n.name for n in task_project.todo()]
     assert todo.index('task 2.2') < todo.index('task 3.2')
     assert todo.index('task 2.2') < todo.index('task 1.2')
     assert todo.index('task 1.1') < todo.index('task 1.2')
 
 
-def test_postorder_default_prioritys_ignored(task_graph):
+def test_postorder_default_prioritys_ignored(task_project):
     """Post-order traversal ignores task prioritys by default"""
-    po = [n.name for _, n in task_graph._postorder()]
+    po = [n.name for _, n in task_project._postorder()]
     assert po.index('task 1.1') < po.index('task 1.3')
 
 
@@ -80,31 +80,31 @@ def test_task_append_task():
     assert rootTask[1] is subTask2
 
 
-def test_task_append(graph):
-    thing1 = graph.append('1st thing')
-    thing2 = graph.append('2nd thing')
-    thing3 = graph.append('3rd thing')
+def test_task_append(project):
+    thing1 = project.append('1st thing')
+    thing2 = project.append('2nd thing')
+    thing3 = project.append('3rd thing')
 
-    assert thing1 is graph[0]
-    assert thing2 is graph[1]
-    assert thing3 is graph[2]
+    assert thing1 is project[0]
+    assert thing2 is project[1]
+    assert thing3 is project[2]
 
     assert thing1.name == '1st thing'
     assert thing2.name == '2nd thing'
     assert thing3.name == '3rd thing'
 
 
-def test_task_pop(graph):
-    assert graph[2].name == '3rd thing'
-    graph.pop(2)
+def test_task_pop(project):
+    assert project[2].name == '3rd thing'
+    project.pop(2)
     with pytest.raises(IndexError) as info:
-        thing3 = graph[2]
+        thing3 = project[2]
         assert "" in str(info.value)
 
 
-def test_task_pop_fail1(graph):
+def test_task_pop_fail1(project):
     with pytest.raises(IndexError):
-        graph.pop(20000)
+        project.pop(20000)
 
 
 def test_task_append_TypeError():
@@ -114,36 +114,36 @@ def test_task_append_TypeError():
         assert "" in str(info.value)
 
 
-def test_blockedby(graph):
-    thing1 = graph[0]
+def test_blockedby(project):
+    thing1 = project[0]
     thing1_1 = thing1.append('thing within a thing')
     thing1_2 = thing1.append('thing blocking a thing')
     thing1_1.blockedby(thing1_2)
     assert thing1_1.blockers[0].name == 'thing blocking a thing'
 
 
-def test_blocking(graph):
-    thing2 = graph[1]
+def test_blocking(project):
+    thing2 = project[1]
     thing2_1 = thing2.append('another thing within a thing')
     thing2_2 = thing2.append('another thing blocking a thing')
     thing2_2.blocking(thing2_1)
     assert thing2_1.blockers[0].name == 'another thing blocking a thing'
 
 
-def test_repr(graph):
-    assert graph.name == 'learn all the things'
+def test_repr(project):
+    assert project.name == 'learn all the things'
 
-    thing1 = graph[0]
-    thing2 = graph[1]
+    thing1 = project[0]
+    thing2 = project[1]
 
     with pytest.raises(IndexError) as info:
-        thing3 = graph[2]
+        thing3 = project[2]
         assert "" in str(info.value)
 
     assert thing1.name == '1st thing'
     assert thing2.name == '2nd thing'
 
-    assert str(graph) == "".join([
+    assert str(project) == "".join([
         "learn all the things:\n",
         "- 1st thing:\n",
         "  - thing within a thing\n",
@@ -154,14 +154,14 @@ def test_repr(graph):
     ])
 
 
-def test_deep_repr(graph):
+def test_deep_repr(project):
 
-    thing2_1 = graph[1][0]
+    thing2_1 = project[1][0]
     assert thing2_1.name == 'another thing within a thing'
 
     thing2_1.append('super deep thing')
 
-    assert str(graph) == "".join([
+    assert str(project) == "".join([
         "learn all the things:\n",
         "- 1st thing:\n",
         "  - thing within a thing\n",
@@ -193,24 +193,24 @@ def test_name_getter_setter():
     assert task.name == 'a new name'
 
 
-def test_to_yaml(graph):
-    assert graph.name == 'learn all the things'
-    assert graph[0].name == '1st thing'
-    graph.to_yaml('mindgraph.yaml')
-    graph2 = read_yaml('mindgraph.yaml')
-    test_repr(graph2)
-    assert repr(graph) == repr(graph2)
-    os.remove('mindgraph.yaml')
+def test_to_yaml(project):
+    assert project.name == 'learn all the things'
+    assert project[0].name == '1st thing'
+    project.to_yaml('project.yaml')
+    project2 = read_yaml('project.yaml')
+    test_repr(project2)
+    assert repr(project) == repr(project2)
+    os.remove('project.yaml')
 
 
 def test_to_yaml_TypeError():
-    not_a_graph = yaml.dump("not a graph")
-    with open('not_a_graph.yaml', 'w') as f:
-        f.write(not_a_graph)
+    not_a_project = yaml.dump("not a project")
+    with open('not_a_project.yaml', 'w') as f:
+        f.write(not_a_project)
     with pytest.raises(TypeError) as info:
-        read_yaml('not_a_graph.yaml')
+        read_yaml('not_a_project.yaml')
         assert "" in str(info.value)
-    os.remove('not_a_graph.yaml')
+    os.remove('not_a_project.yaml')
 
 
 def test_parser():

--- a/test/test_mindgraph.py
+++ b/test/test_mindgraph.py
@@ -122,12 +122,24 @@ def test_blockedby(project):
     assert thing1_1.blockers[0].name == 'thing blocking a thing'
 
 
+def test_blockedby_TypeError():
+    with pytest.raises(TypeError):
+        task = Task('mytask')
+        task.blockedby(47)
+
+
 def test_blocking(project):
     thing2 = project[1]
     thing2_1 = thing2.append('another thing within a thing')
     thing2_2 = thing2.append('another thing blocking a thing')
     thing2_2.blocking(thing2_1)
     assert thing2_1.blockers[0].name == 'another thing blocking a thing'
+
+
+def test_blocking_TypeError():
+    with pytest.raises(TypeError):
+        task = Task('mytask')
+        task.blocking(47)
 
 
 def test_repr(project):

--- a/test/test_mindgraph.py
+++ b/test/test_mindgraph.py
@@ -12,14 +12,14 @@ from mindgraph import *
 
 @pytest.fixture(scope="module")
 def graph():
-    graph = project('learn all the things')
+    graph = Project('learn all the things')
     return graph
 
 
 @pytest.fixture
 def task_graph():
     # setup example graph from issue #14
-    g = project('build a thing')
+    g = Project('build a thing')
 
     t1 = g.append('task 1')
     t1.priority = 3
@@ -61,26 +61,26 @@ def test_todo_blocking_tasks_win(task_graph):
 
 
 def test_postorder_default_prioritys_ignored(task_graph):
-    """Post-order traversal ignores node prioritys by default"""
+    """Post-order traversal ignores task prioritys by default"""
     po = [n.name for _, n in task_graph._postorder()]
     assert po.index('task 1.1') < po.index('task 1.3')
 
 
-def test_node_init_typeerror():
+def test_task_init_typeerror():
     with pytest.raises(TypeError) as info:
-        node = Task(47)
+        task = Task(47)
         assert "" in str(info.value)
 
 
-def test_node_append_node():
-    rootTask = Task('root node')
-    subTask1 = rootTask.append(Task('sub node'))
-    subTask2 = rootTask.append(Task('sub node 2'))
+def test_task_append_task():
+    rootTask = Task('root task')
+    subTask1 = rootTask.append(Task('sub task'))
+    subTask2 = rootTask.append(Task('sub task 2'))
     assert rootTask[0] is subTask1
     assert rootTask[1] is subTask2
 
 
-def test_node_append(graph):
+def test_task_append(graph):
     thing1 = graph.append('1st thing')
     thing2 = graph.append('2nd thing')
     thing3 = graph.append('3rd thing')
@@ -94,7 +94,7 @@ def test_node_append(graph):
     assert thing3.name == '3rd thing'
 
 
-def test_node_pop(graph):
+def test_task_pop(graph):
     assert graph[2].name == '3rd thing'
     graph.pop(2)
     with pytest.raises(IndexError) as info:
@@ -102,15 +102,15 @@ def test_node_pop(graph):
         assert "" in str(info.value)
 
 
-def test_node_pop_fail1(graph):
+def test_task_pop_fail1(graph):
     with pytest.raises(IndexError):
         graph.pop(20000)
 
 
-def test_node_append_TypeError():
+def test_task_append_TypeError():
     with pytest.raises(TypeError) as info:
-        node = Task('mynode')
-        node.append(47)
+        task = Task('mytask')
+        task.append(47)
         assert "" in str(info.value)
 
 
@@ -176,21 +176,21 @@ def test_deep_repr(graph):
 
 
 def test_priority_getter_setter():
-    node = Task('myTask')
-    default_priority = node.priority
-    node.priority = 5
+    task = Task('myTask')
+    default_priority = task.priority
+    task.priority = 5
 
     assert default_priority == 1
-    assert node.priority == 5
+    assert task.priority == 5
 
 
 def test_name_getter_setter():
-    node = Task()
-    default_name = node.name
-    node.name = 'a new name'
+    task = Task()
+    default_name = task.name
+    task.name = 'a new name'
 
     assert default_name == ''
-    assert node.name == 'a new name'
+    assert task.name == 'a new name'
 
 
 def test_to_yaml(graph):


### PR DESCRIPTION
closes #21 

Additions:
 - Moved `to_yaml` method from `Project` to `Task` class
 - converted `Project` class to `project` factory method that returns a `Task` object